### PR TITLE
Instant subtitle toggle

### DIFF
--- a/src/utils/katamari.js
+++ b/src/utils/katamari.js
@@ -9463,12 +9463,12 @@
                                         i1({
                                             shortcut: tK.ToggleSubs,
                                             handleShortcut: () => {
-                                                if (p && 'none' !== p.language) {
-                                                    let t = u.find((t) => 'none' === t.language)
-                                                    t && r.setTextTrack(t)
-                                                } else {
-                                                    let t = u.find((t) => 'none' !== t.language)
-                                                    t && r.setTextTrack(t)
+                                                let t = document.querySelectorAll('.libassjs-canvas-parent, .croptix-vtt-cue-overlay, .shaka-text-container')
+                                                if (t.length > 0) {
+                                                    let isHidden = t[0].style.display === 'none'
+                                                    t.forEach((el) => {
+                                                        el.style.display = isHidden ? '' : 'none'
+                                                    })
                                                 }
                                             }
                                         }))


### PR DESCRIPTION
As mentioned in [issue #49](https://github.com/stratumadev/croptix/issues/49#issuecomment-5483734781),

Right now, when we press the shortcut, the subtitles turn off immediately. However, when we toggle them back on, we have to wait quite a bit before they appear again. In some use cases, this can be inconvenient.

By default, toggling between "None" and t.language is not instantaneous. So, the proposed solution is to select the subtitle element and set it to hidden at the CSS level instead of toggling the subtitle language internally.

I don't think this is a permanent solution, though, because it might confuse users when the menu shows a particular language but the subtitles are hidden. If there is a better way to handle this, please let me know.